### PR TITLE
Event hub records

### DIFF
--- a/NwNsgProject/obEventHub.cs
+++ b/NwNsgProject/obEventHub.cs
@@ -12,7 +12,8 @@ namespace NwNsgProject
 {
     public partial class Util
     {
-        const int MAXTRANSMISSIONSIZE = 255 * 1024;
+//        const int MAXTRANSMISSIONSIZE = 255 * 1024;
+        const int MAXTRANSMISSIONSIZE = 2 * 1024;
 
         public static async Task obEventHub(string newClientContent, TraceWriter log)
         {

--- a/NwNsgProject/obEventHub.cs
+++ b/NwNsgProject/obEventHub.cs
@@ -39,6 +39,8 @@ namespace NwNsgProject
         static System.Collections.Generic.IEnumerable<string> bundleMessages(string newClientContent, TraceWriter log)
         {
             var transmission = new StringBuilder(MAXTRANSMISSIONSIZE);
+            transmission.Append("{\"records\":[");
+            bool firstRecord = true;
             foreach (var message in denormalizeRecords(newClientContent, null, log))
             {
                 //
@@ -65,13 +67,28 @@ namespace NwNsgProject
 
                 if (transmission.Length + message.Length > MAXTRANSMISSIONSIZE)
                 {
+                    transmission.Append("]}");
                     yield return transmission.ToString();
                     transmission.Clear();
+                    transmission.Append("{\"records\":[");
+                    firstRecord = true;
                 }
+
+                // add comma after existing transmission if it's not the first record
+                if (firstRecord)
+                {
+                    firstRecord = false;
+                }
+                else
+                {
+                    transmission.Append(",");
+                }
+
                 transmission.Append(message);
             }
             if (transmission.Length > 0)
             {
+                transmission.Append("]}");
                 yield return transmission.ToString();
             }
         }

--- a/NwNsgProject/obEventHub.cs
+++ b/NwNsgProject/obEventHub.cs
@@ -12,8 +12,8 @@ namespace NwNsgProject
 {
     public partial class Util
     {
-//        const int MAXTRANSMISSIONSIZE = 255 * 1024;
-        const int MAXTRANSMISSIONSIZE = 2 * 1024;
+        const int MAXTRANSMISSIONSIZE = 255 * 1024;
+//        const int MAXTRANSMISSIONSIZE = 2 * 1024;
 
         public static async Task obEventHub(string newClientContent, TraceWriter log)
         {
@@ -33,6 +33,8 @@ namespace NwNsgProject
 
             foreach (var bundleOfMessages in bundleMessages(newClientContent, log))
             {
+                //log.Info(String.Format("-----Outgoing message is: {0}", bundleOfMessages));
+
                 await eventHubClient.SendAsync(new EventData(Encoding.UTF8.GetBytes(bundleOfMessages)));
             }
         }


### PR DESCRIPTION
add the {"records":[ … ]} wrapper to the event hub output binding.