### PR TITLE
Fix for Web deployment failed with conflict

### DIFF
--- a/NwNsgProject/NwNsgProject.csproj
+++ b/NwNsgProject/NwNsgProject.csproj
@@ -6,7 +6,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.2.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.3" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.24" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.8" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.36" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
Fix for issue https://github.com/microsoft/AzureNetworkWatcherNSGFlowLogsConnector/issues/10

Web deployment was failing on multiple attempts with message `
The resource operation completed with terminal provisioning state 'Failed'.`

ARM template change https://github.com/sebastus/AzureFunctionDeployment/pull/7

Changes:

- [x] Updated `Microsoft.NET.Sdk.Functions` version to `1.0.36`
- [x] Add package `Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator` for issue `error: Metadata generation failed.`