### PR TITLE
Updated libraries and Azure Function version, EventHub output bug fix.

### DIFF
--- a/NwNsgProject/BlobTriggerIngestAndTransmit.cs
+++ b/NwNsgProject/BlobTriggerIngestAndTransmit.cs
@@ -1,11 +1,12 @@
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
-using Microsoft.WindowsAzure.Storage.Blob;
-using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.Azure.Storage.Blob;
+using Microsoft.Azure.Cosmos.Table;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Buffers;
+
 
 namespace nsgFunc
 {

--- a/NwNsgProject/Checkpoint.cs
+++ b/NwNsgProject/Checkpoint.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.WindowsAzure.Storage.Table;
+﻿using Microsoft.Azure.Cosmos.Table;
 
 namespace nsgFunc
 {

--- a/NwNsgProject/NwNsgProject.csproj
+++ b/NwNsgProject/NwNsgProject.csproj
@@ -1,12 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <AzureFunctionsVersion>v2</AzureFunctionsVersion>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.2.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.3" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.24" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Azure.EventHubs" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.2" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/NwNsgProject/RescanAPI.cs
+++ b/NwNsgProject/RescanAPI.cs
@@ -1,18 +1,16 @@
 using System;
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
-using Microsoft.WindowsAzure.Storage.Table;
-using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.Azure.Storage.Blob;
+using Microsoft.Azure.Cosmos.Table;
 
 namespace nsgFunc
 {
-    public static class RescanAPI
+  public static class RescanAPI
     {
         // https://<APP_NAME>.azurewebsites.net/api/rescan/2/17/8
         //

--- a/NwNsgProject/Util.cs
+++ b/NwNsgProject/Util.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
-using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.Azure.Storage.Blob;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;

--- a/NwNsgProject/classes.cs
+++ b/NwNsgProject/classes.cs
@@ -87,6 +87,7 @@ class DenormalizedRecord
         this.destinationAddress = tuple.destinationAddress;
         this.sourcePort = tuple.sourcePort;
         this.destinationPort = tuple.destinationPort;
+        this.transportProtocol = tuple.transportProtocol;
         this.deviceDirection = tuple.deviceDirection;
         this.deviceAction = tuple.deviceAction;
         if (this.version >= 2.0)
@@ -262,6 +263,7 @@ class DenormalizedRecord
         objectSize += this.destinationPort.Length + 15 + 6;
         objectSize += this.deviceDirection.Length + 15 + 6;
         objectSize += this.deviceAction.Length + 12 + 6;
+        objectSize += this.transportProtocol.Length + 17 + 6;
         if (this.version >= 2.0)
         {
             objectSize += this.flowState.Length + 9 + 6;

--- a/NwNsgProject/obArcSight.cs
+++ b/NwNsgProject/obArcSight.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
-using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.Azure.Storage.Blob;
 using System;
 using System.Buffers;
 using System.Net.Sockets;


### PR DESCRIPTION
1. Updated framework and Azure libraries to current versions.
2. Updated Azure Function version to v3.
3. Added transportProtocol into EventHub output.

This fork is current running in Production for our NSG flow log ingest pipeline.