### PR TITLE
fix missing transportProtocol

### DIFF
--- a/NwNsgProject/classes.cs
+++ b/NwNsgProject/classes.cs
@@ -87,6 +87,7 @@ class DenormalizedRecord
         this.destinationAddress = tuple.destinationAddress;
         this.sourcePort = tuple.sourcePort;
         this.destinationPort = tuple.destinationPort;
+        this.transportProtocol = tuple.transportProtocol;
         this.deviceDirection = tuple.deviceDirection;
         this.deviceAction = tuple.deviceAction;
         if (this.version >= 2.0)
@@ -260,6 +261,7 @@ class DenormalizedRecord
         objectSize += this.destinationAddress.Length + 18 + 6;
         objectSize += this.sourcePort.Length + 10 + 6;
         objectSize += this.destinationPort.Length + 15 + 6;
+        objectSize += this.transportProtocol.Length + 17 + 6
         objectSize += this.deviceDirection.Length + 15 + 6;
         objectSize += this.deviceAction.Length + 12 + 6;
         if (this.version >= 2.0)

--- a/NwNsgProject/classes.cs
+++ b/NwNsgProject/classes.cs
@@ -261,7 +261,7 @@ class DenormalizedRecord
         objectSize += this.destinationAddress.Length + 18 + 6;
         objectSize += this.sourcePort.Length + 10 + 6;
         objectSize += this.destinationPort.Length + 15 + 6;
-        objectSize += this.transportProtocol.Length + 17 + 6
+        objectSize += this.transportProtocol.Length + 17 + 6;
         objectSize += this.deviceDirection.Length + 15 + 6;
         objectSize += this.deviceAction.Length + 12 + 6;
         if (this.version >= 2.0)


### PR DESCRIPTION
Noticed that transportProtocol was always null, this commit should fix that.